### PR TITLE
Fix typo token in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ final openAI = OpenAI.instance.build(token: token,baseOption: HttpSetup(receiveT
 
 ```dart
 openAI.setToken('new-access-token');
-///get toekn
+///get token
 openAI.token;
 ```
 


### PR DESCRIPTION
Just a quick fix of a typo in the readme.md file