### PR TITLE
Add reponse_format support and gpt-3.5-turbo-1106 define

### DIFF
--- a/lib/chat_gpt_sdk.dart
+++ b/lib/chat_gpt_sdk.dart
@@ -44,3 +44,4 @@ export 'src/model/chat_complete/enum/role.dart';
 export 'src/model/chat_complete/enum/function_call.dart';
 export 'src/model/chat_complete/request/messages.dart';
 export 'src/model/chat_complete/request/function_data.dart';
+export 'src/model/chat_complete/request/response_format.dart';

--- a/lib/src/model/chat_complete/enum/chat_model.dart
+++ b/lib/src/model/chat_complete/enum/chat_model.dart
@@ -37,6 +37,10 @@ class GptTurbo0631Model extends ChatModel {
   GptTurbo0631Model() : super(model: kChatGptTurbo0613);
 }
 
+class GptTurbo1106Model extends ChatModel {
+  GptTurbo1106Model() : super(model: kChatGptTurbo1106);
+}
+
 class GptTurbo16k0631Model extends ChatModel {
   GptTurbo16k0631Model() : super(model: kChatGptTurbo16k0613);
 }

--- a/lib/src/model/chat_complete/request/chat_complete_text.dart
+++ b/lib/src/model/chat_complete/request/chat_complete_text.dart
@@ -2,6 +2,7 @@ import 'package:chat_gpt_sdk/src/model/chat_complete/enum/chat_model.dart';
 import 'package:chat_gpt_sdk/src/model/chat_complete/enum/function_call.dart';
 import 'package:chat_gpt_sdk/src/model/chat_complete/request/function_data.dart';
 import 'package:chat_gpt_sdk/src/model/chat_complete/request/messages.dart';
+import 'package:chat_gpt_sdk/src/model/chat_complete/request/response_format.dart';
 
 class ChatCompleteText {
   ///ID of the model to use. Currently, only gpt-3.5-turbo and
@@ -37,6 +38,11 @@ class ChatCompleteText {
   /// are present. "auto" is the default if functions are present.{"name":\ "my_function"}
   /// [functionCall]
   final FunctionCall? functionCall;
+
+  ///Defines the format of the model's response output. Currently, only supports
+  /// "json_object", and it is available only for certain models.
+  /// [responseFormat]
+  final ResponseFormat? responseFormat;
 
   ///What sampling temperature to use, between 0 and
   ///2. Higher values like 0.8 will make the output more random,
@@ -111,6 +117,7 @@ class ChatCompleteText {
     this.user = "",
     this.functions,
     this.functionCall,
+    this.responseFormat,
   });
 
   Map<String, dynamic> toJson() {
@@ -130,6 +137,7 @@ class ChatCompleteText {
             "presence_penalty": presencePenalty,
             "frequency_penalty": frequencyPenalty,
             "user": user,
+            "response_format": responseFormat?.toJson(),
           })
         : Map.of({
             "model": model.model,
@@ -143,6 +151,7 @@ class ChatCompleteText {
             "presence_penalty": presencePenalty,
             "frequency_penalty": frequencyPenalty,
             "user": user,
+            "response_format": responseFormat?.toJson(),
           })
       ..removeWhere((key, value) => value == null);
 

--- a/lib/src/model/chat_complete/request/response_format.dart
+++ b/lib/src/model/chat_complete/request/response_format.dart
@@ -1,0 +1,14 @@
+class ResponseFormat {
+  final String type;
+
+  ResponseFormat({required this.type});
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['type'] = type;
+
+    return data;
+  }
+
+  static final jsonObject = ResponseFormat(type: "json_object");
+}

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -60,6 +60,7 @@ const kChatGpt40314 = 'gpt-4-0314';
 const kChatGpt432k = 'gpt-4-32k';
 const kChatGpt432k0314 = 'gpt-4-32k-0314';
 const kChatGptTurbo0613 = 'gpt-3.5-turbo-0613';
+const kChatGptTurbo1106 = 'gpt-3.5-turbo-1106';
 const kChatGptTurbo16k0613 = 'gpt-3.5-turbo-16k-0613';
 const kChatGpt40631 = 'gpt-4-0613';
 


### PR DESCRIPTION
This pr add a new option `response_format` to the `gpt-3.5-turbo-1106` and `gpt-4-1106-preview` models.
It can set to `json_object` to make sure replies are in a JSON format.

More info: [https://platform.openai.com/docs/guides/text-generation/json-mode](https://platform.openai.com/docs/guides/text-generation/json-mode)