### PR TITLE
Added json_schema support to ResponseFormat

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -31,7 +31,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "3.1.2"
   clock:
     dependency: transitive
     description:

--- a/example_app/openai_app/pubspec.lock
+++ b/example_app/openai_app/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "3.1.2"
   clock:
     dependency: transitive
     description:

--- a/lib/chat_gpt_sdk.dart
+++ b/lib/chat_gpt_sdk.dart
@@ -43,6 +43,7 @@ export 'src/model/chat_complete/response/chat_response_sse.dart';
 export 'src/model/chat_complete/enum/role.dart';
 export 'src/model/chat_complete/enum/function_call.dart';
 export 'src/model/chat_complete/request/messages.dart';
+export 'src/model/chat_complete/request/json_schema.dart';
 export 'src/model/chat_complete/request/function_data.dart';
 export 'src/model/chat_complete/request/response_format.dart';
 export 'src/model/gen_image/enum/generate_image_model.dart';

--- a/lib/src/model/chat_complete/request/json_schema.dart
+++ b/lib/src/model/chat_complete/request/json_schema.dart
@@ -1,0 +1,16 @@
+class JsonSchema {
+  final String name;
+  final Map<String, dynamic> schema;
+  final bool strict = true;
+
+  JsonSchema({required this.name, required this.schema});
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['name'] = name;
+    data['schema'] = schema;
+    data['strict'] = strict;
+
+    return data;
+  }
+}

--- a/lib/src/model/chat_complete/request/response_format.dart
+++ b/lib/src/model/chat_complete/request/response_format.dart
@@ -1,11 +1,19 @@
+import 'package:chat_gpt_sdk/src/model/chat_complete/request/json_schema.dart';
+
 class ResponseFormat {
   final String type;
+  final JsonSchema? json_schema;
 
-  ResponseFormat({required this.type});
+  ResponseFormat({required this.type, this.json_schema});
+
+  ResponseFormat.jsonSchema({required this.json_schema}) : type = 'json_schema';
 
   Map<String, dynamic> toJson() {
     final data = <String, dynamic>{};
     data['type'] = type;
+    if (json_schema != null) {
+      data['json_schema'] = json_schema!.toJson();
+    }
 
     return data;
   }


### PR DESCRIPTION
Updated the ResponseFormat class to support the 'json_schema' type. This allows the 'Structured outputs' functionality to be used.
https://platform.openai.com/docs/guides/structured-outputs

Added a convenience initialiser to construct a ResponseFormat with a JsonSchema object. This object takes a name and a json object, which is expect to confirm to the OpenAI schema description. Generating a schema is out of scope for this PR.

A working example of this can be seen in the OpenAI cookbook - https://cookbook.openai.com/examples/structured_outputs_intro