### PR TITLE
Added support for image data i.e, type (image_file, image_url) in content v2 model

### DIFF
--- a/example_app/openai_app/pubspec.lock
+++ b/example_app/openai_app/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "3.1.2"
+    version: "3.1.3"
   clock:
     dependency: transitive
     description:

--- a/lib/src/model/message/response/content_v2.dart
+++ b/lib/src/model/message/response/content_v2.dart
@@ -1,21 +1,35 @@
 import 'package:chat_gpt_sdk/src/model/message/response/text_data.dart';
+import 'package:chat_gpt_sdk/src/model/message/response/image_data.dart';
 
 class ContentV2 {
   String type;
-  TextData text;
+  TextData? text;
+  ImageData? image;
 
   ContentV2({
     required this.type,
-    required this.text,
+    this.text,
+    this.image,
   });
 
-  factory ContentV2.fromJson(Map<String, dynamic> json) => ContentV2(
-        type: json["type"],
-        text: TextData.fromJson(json["text"]),
-      );
+  factory ContentV2.fromJson(Map<String, dynamic> json) {
+    final type = json["type"];
+    final image = (type == 'image_url' || type == 'image_file')
+        ? json[type] != null
+        ? ImageData.fromJson(json[type]!)
+        : null
+        : null;
+
+    return ContentV2(
+      type: type,
+      text: type == 'text' && json["text"] != null ? TextData.fromJson(json["text"]!) : null,
+      image: image,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
-        "type": type,
-        "text": text.toJson(),
-      };
+    "type": type,
+    "text": text?.toJson(),
+    type: image?.toJson(), // Dynamically set 'image_url' or 'image_file'
+  };
 }

--- a/lib/src/model/message/response/image_data.dart
+++ b/lib/src/model/message/response/image_data.dart
@@ -1,0 +1,23 @@
+class ImageData {
+  String? url;
+  String? fileId;
+  String? detail;
+
+  ImageData({
+    this.url,
+    this.fileId,
+    this.detail,
+  });
+
+  factory ImageData.fromJson(Map<String, dynamic> json) => ImageData(
+    fileId: json["file_id"] ?? '',
+    url: json["url"] ?? '',
+    detail: json["detail"] ?? '',
+  );
+
+  Map<String, dynamic> toJson() => {
+    "file_id": fileId,
+    "url": url,
+    "detail": detail,
+  };
+}


### PR DESCRIPTION
The update introduces support for handling image data in the content v2 model, specifically with the types image_file and image_url. Previously, the model was throwing errors when attempting to process image data, as it wasn't handling these formats correctly.

image_file: Allows users to upload image files directly into the model.
image_url: Enables the use of image URLs to reference external images.
By adding this support, the issue is resolved, preventing errors in the response and ensuring proper handling of image data.